### PR TITLE
Use actions/create-release for creating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-on: release
+on: push
 name: Build my extension
 jobs:
   buildAIX:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,28 @@ name: Build my extension
 jobs:
   buildAIX:
     name: Build AIX
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
     - name: Build AIX
       uses: pavi2410/AIX-Action@master
-    - name: Publish AIX
-      uses: JasonEtco/upload-to-release@master
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1.0.0
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: /github/workspace/appinventor-sources/appinventor/components/build/extensions/tk.pavi2410.aix
-          application/zip
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: appinventor-sources/appinventor/components/build/extensions/tk.pavi2410.aix
+        asset_name: tk.pavi2410.aix
+        asset_content_type: application/zip


### PR DESCRIPTION
This RP;
* Replaces "Publish AIX" step with [actions/create-release](https://github.com/actions/create-release) and [actions/upload-release-asset](https://github.com/actions/upload-release-asset) for better performance. And it saves release as draft, so user can download the AIX file without publishing the release.
* Fixes the "File not found" error when uploading the compiled AIX to the release by deleting `/github/workspace/` directory from path, because action is already working under `/github/workspace` directory.
* Replaces action trigger to `push` instead of `release` since it is more suitable to run action after every commit.
